### PR TITLE
Multiple Fish conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,8 @@
-
-# JPE App Server Test
-
-
+# JPE App Server
 
 ## Usage
 
-This server uses node-postgres to make queries to our Azure DB directly.
-The bulk of this functionality can be found in `src/db/index.ts`
-
-```javascript
-export default {
-  query: (text: string, params: any[]) => pool.query(text, params),
-}
-```
-
-
-
+This server uses express and knex to receive http requests and make queries to the Azure Postgresql DB directly.
 
 ## Environment Variables
 
@@ -29,9 +16,8 @@ To run this project, you will need to add the following environment variables to
 
 `AZURE_DB`
 
+`AZURE_PORT`
 
-## Insomnia Testing
+`AZURE_SSL`
 
-After spinning up the server, try sending a get request to `http://localhost:8000/azure-testing/agency`
-to recieve this data from our DB
-
+`PORT`

--- a/src/models/catchRaw/index.ts
+++ b/src/models/catchRaw/index.ts
@@ -143,13 +143,13 @@ async function createCatchRaw(catchRawValues): Promise<{
   createdCatchFishConditionResponse: Array<CatchFishConditionI>
 }> {
   try {
-    const existingMarks = catchRawValues?.existingMarks
+    const existingMarks = catchRawValues?.existingMarks || []
     delete catchRawValues?.existingMarks
-    const geneticSamplingData = catchRawValues?.geneticSamplingData
+    const geneticSamplingData = catchRawValues?.geneticSamplingData || []
     delete catchRawValues?.geneticSamplingData
-    const appliedMarks = catchRawValues?.appliedMarks
+    const appliedMarks = catchRawValues?.appliedMarks || []
     delete catchRawValues?.appliedMarks
-    const catchFishCondition = catchRawValues?.fishCondition
+    const catchFishCondition = catchRawValues?.fishCondition || []
     delete catchRawValues?.fishCondition
 
     const createdCatchRawResponse = await knex<CatchRaw>('catchRaw').insert(


### PR DESCRIPTION
Allows for a single catch raw entry to contain multiple fish conditions.

-  Adds `catch_fish_condition` table 

Relates to Client PR [#327](https://github.com/SRJPE/rst-pilot-app-client/pull/327)